### PR TITLE
Add AccentActivity to make it easier to get started

### DIFF
--- a/HoloAccent/build.gradle
+++ b/HoloAccent/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android-library'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "18.1.1"
+    buildToolsVersion "19.0.0"
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 19

--- a/HoloAccent/src/com/negusoft/holoaccent/AccentActivity.java
+++ b/HoloAccent/src/com/negusoft/holoaccent/AccentActivity.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright 2013 NEGU Soft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.negusoft.holoaccent;
+
+import android.app.Activity;
+import android.content.res.Resources;
+
+public abstract class AccentActivity extends Activity {
+
+    // When no code override of the accent is requested, overrideAccentColor() will return the
+    // identity hash of the Integer object on the heap, which is the same one against which we
+    // are comparing. Therefore, we will not override the theme. As soon as a user overrides
+    // overrideAccentColor(), the identity hash of the returned Integer will be different,
+    // and we will override the theme from XML.
+    protected final AccentHelper mAccentHelper = new AccentHelper(overrideAccentColor(),
+            System.identityHashCode(overrideAccentColor()) != System.identityHashCode
+                    (AccentHelper.NO_OVERRIDE));
+
+    @Override
+    public Resources getResources() {
+        return mAccentHelper.getResources(this, super.getResources());
+    }
+
+    /**
+     * Programmatically set the accent color.
+     *
+     * Called in the constructor to determine if the color specified in XML should be overridden.
+     * Override in child {@link android.app.Activity Activities}.
+     */
+    protected Integer overrideAccentColor() {
+        // This method MUST return an Integer object rather than the primitive. Returning the
+        // primitive will result in really strange behavior.
+
+        // By default do not override
+        return AccentHelper.NO_OVERRIDE;
+    }
+
+}

--- a/HoloAccent/src/com/negusoft/holoaccent/AccentHelper.java
+++ b/HoloAccent/src/com/negusoft/holoaccent/AccentHelper.java
@@ -58,22 +58,30 @@ import android.content.res.Resources;
  * prepareDialog().
  */
 public class AccentHelper {
+
+    static final Integer NO_OVERRIDE = Integer.MIN_VALUE;
 	
 	private AccentResources mAccentResources;
 	private DividerPainter mDividerPainter;
-	
-	private final boolean mOverrideThemeColor;
+
+    private final boolean mOverrideThemeColor;
 	private final int mOverrideColor;
-	
+
+    // Need for backwards compatibility & custom implementation
 	public AccentHelper() {
-		mOverrideThemeColor = false;
-		mOverrideColor = 0;
+        this(0, false);
 	}
-	
+
+    // Need for backwards compatibility & custom implementation
 	public AccentHelper(int color) {
-		mOverrideThemeColor = true;
-		mOverrideColor = color;
+        this(color, true);
 	}
+
+    // Keep package to avoid possible misuse in conjunction w/ AccentActivity
+    AccentHelper(int color, boolean overrideThemeColor) {
+        mOverrideColor = color;
+        mOverrideThemeColor = overrideThemeColor;
+    }
 	
 	/** @return The AccentResources instance, properly initialized. */
 	public Resources getResources(Context c, Resources resources) {
@@ -90,7 +98,7 @@ public class AccentHelper {
 	}
 	
 	private AccentResources createInstance(Context c, Resources resources) {
-		if (mOverrideThemeColor)
+        if (mOverrideThemeColor)
 			return new AccentResources(c, resources, mOverrideColor);
 		return new AccentResources(c, resources);
 	}

--- a/HoloAccent/src/com/negusoft/holoaccent/AccentHelper.java
+++ b/HoloAccent/src/com/negusoft/holoaccent/AccentHelper.java
@@ -58,22 +58,30 @@ import android.content.res.Resources;
  * prepareDialog().
  */
 public class AccentHelper {
+
+    static final Integer NO_OVERRIDE = 0;
 	
 	private AccentResources mAccentResources;
 	private DividerPainter mDividerPainter;
-	
-	private final boolean mOverrideThemeColor;
+
+    private final boolean mOverrideThemeColor;
 	private final int mOverrideColor;
-	
+
+    // Need for backwards compatibility & custom implementation
 	public AccentHelper() {
-		mOverrideThemeColor = false;
-		mOverrideColor = 0;
+        this(0, false);
 	}
-	
+
+    // Need for backwards compatibility & custom implementation
 	public AccentHelper(int color) {
-		mOverrideThemeColor = true;
-		mOverrideColor = color;
+        this(color, true);
 	}
+
+    // Keep package to avoid possible misuse in conjunction w/ AccentActivity
+    AccentHelper(int color, boolean overrideThemeColor) {
+        mOverrideColor = color;
+        mOverrideThemeColor = overrideThemeColor;
+    }
 	
 	/** @return The AccentResources instance, properly initialized. */
 	public Resources getResources(Context c, Resources resources) {
@@ -90,7 +98,7 @@ public class AccentHelper {
 	}
 	
 	private AccentResources createInstance(Context c, Resources resources) {
-		if (mOverrideThemeColor)
+        if (mOverrideThemeColor)
 			return new AccentResources(c, resources, mOverrideColor);
 		return new AccentResources(c, resources);
 	}

--- a/HoloAccentExample/build.gradle
+++ b/HoloAccentExample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "18.1.1"
+    buildToolsVersion "19.0.0"
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 19
@@ -18,5 +18,5 @@ android {
 
 dependencies {
     compile project(":HoloAccent")
-    compile 'com.android.support:support-v4:18.0.0'
+    compile 'com.android.support:support-v13:+'
 }

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/CodeOverrideActivity.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/CodeOverrideActivity.java
@@ -1,16 +1,11 @@
 package com.negusoft.holoaccent.example;
 
-import android.content.res.Resources;
 import android.graphics.Color;
 
-import com.negusoft.holoaccent.AccentHelper;
-
 public class CodeOverrideActivity extends TabbedActivity {
-	
-	private final AccentHelper mAccentHelper = new AccentHelper(Color.RED);
-	@Override
-	public Resources getResources() {
-		return mAccentHelper.getResources(this, super.getResources());
-	}
 
+    @Override
+    protected Integer overrideAccentColor() {
+        return Color.RED;
+    }
 }

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/DialogActivity.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/DialogActivity.java
@@ -1,9 +1,6 @@
 package com.negusoft.holoaccent.example;
 
-import android.content.res.Resources;
 import android.os.Bundle;
-
-import com.negusoft.holoaccent.AccentHelper;
 
 public class DialogActivity extends SpinnerActivity {
 	
@@ -11,12 +8,6 @@ public class DialogActivity extends SpinnerActivity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		mAccentHelper.prepareDialog(this, getWindow());
-	}
-	
-	private final AccentHelper mAccentHelper = new AccentHelper();
-	@Override
-	public Resources getResources() {
-		return mAccentHelper.getResources(this, super.getResources());
 	}
 
 }

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/PreferencesActivity.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/PreferencesActivity.java
@@ -1,29 +1,21 @@
 package com.negusoft.holoaccent.example;
 
-import android.app.Activity;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.preference.PreferenceFragment;
 
-import com.negusoft.holoaccent.AccentHelper;
+import com.negusoft.holoaccent.AccentActivity;
 
-public class PreferencesActivity extends Activity {
+public class PreferencesActivity extends AccentActivity {
 
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
         // Display the fragment as the main content.
         getFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new GeneralPreferenceFragment())
                 .commit();
-	}
-	
-	private final AccentHelper mAccentHelper = new AccentHelper();
-	@Override
-	public Resources getResources() {
-		return mAccentHelper.getResources(this, super.getResources());
-	}
+    }
 
 //	@Override
 //	public boolean onOptionsItemSelected(MenuItem item) {
@@ -35,11 +27,11 @@ public class PreferencesActivity extends Activity {
 //		return super.onOptionsItemSelected(item);
 //	}
 
-	public static class GeneralPreferenceFragment extends PreferenceFragment {
-		@Override
-		public void onCreate(Bundle savedInstanceState) {
-			super.onCreate(savedInstanceState);
-			addPreferencesFromResource(R.xml.pref_general);
-		}
-	}
+    public static class GeneralPreferenceFragment extends PreferenceFragment {
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            addPreferencesFromResource(R.xml.pref_general);
+        }
+    }
 }

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/SpinnerActivity.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/SpinnerActivity.java
@@ -1,16 +1,14 @@
 package com.negusoft.holoaccent.example;
 
 import android.app.ActionBar;
-import android.app.Activity;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.Menu;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 
-import com.negusoft.holoaccent.AccentHelper;
+import com.negusoft.holoaccent.AccentActivity;
 
-public class SpinnerActivity extends Activity {
+public class SpinnerActivity extends AccentActivity {
 
 	private static final String[] ITEMS = new String[] { "Item 1", "Item 2", "Item 3", "Item 4" };
 
@@ -45,12 +43,6 @@ public class SpinnerActivity extends Activity {
 		spinner1.setAdapter(new MyArrayAdapter());
 		Spinner spinner2 = (Spinner)findViewById(R.id.spinner2);
 		spinner2.setAdapter(new MyArrayAdapter());
-	}
-	
-	private final AccentHelper mAccentHelper = new AccentHelper();
-	@Override
-	public Resources getResources() {
-		return mAccentHelper.getResources(this, super.getResources());
 	}
 
 	@Override

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/TabbedActivity.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/TabbedActivity.java
@@ -8,16 +8,14 @@ import android.app.ActionBar.Tab;
 import android.app.FragmentTransaction;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.res.Resources;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentActivity;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentPagerAdapter;
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.support.v13.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.view.Menu;
 
-import com.negusoft.holoaccent.AccentHelper;
+import com.negusoft.holoaccent.AccentActivity;
 import com.negusoft.holoaccent.dialog.AccentAlertDialog;
 import com.negusoft.holoaccent.example.fragment.ProgressFragment;
 import com.negusoft.holoaccent.example.fragment.ButtonFragment;
@@ -25,7 +23,7 @@ import com.negusoft.holoaccent.example.fragment.ChoicesFragment;
 import com.negusoft.holoaccent.example.fragment.ListFragment;
 import com.negusoft.holoaccent.example.fragment.TextviewFragment;
 
-public class TabbedActivity extends FragmentActivity implements ActionBar.TabListener {
+public class TabbedActivity extends AccentActivity implements ActionBar.TabListener {
 
 	SectionsPagerAdapter mSectionsPagerAdapter;
 	ViewPager mViewPager;
@@ -39,7 +37,7 @@ public class TabbedActivity extends FragmentActivity implements ActionBar.TabLis
 		if (actionBar != null) {
 			actionBar.setHomeButtonEnabled(true);
 
-			FragmentManager fragmentManager = getSupportFragmentManager();
+			FragmentManager fragmentManager = getFragmentManager();
 			mSectionsPagerAdapter = new SectionsPagerAdapter(fragmentManager);
 			mViewPager = (ViewPager) findViewById(R.id.pager);
 			mViewPager.setAdapter(mSectionsPagerAdapter);
@@ -65,12 +63,6 @@ public class TabbedActivity extends FragmentActivity implements ActionBar.TabLis
 					.setTabListener(this);
 			actionBar.addTab(newTab);
 		}
-	}
-	
-	private final AccentHelper mAccentHelper = new AccentHelper();
-	@Override
-	public Resources getResources() {
-		return mAccentHelper.getResources(this, super.getResources());
 	}
 	
 	@Override

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/ButtonFragment.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/ButtonFragment.java
@@ -1,7 +1,7 @@
 package com.negusoft.holoaccent.example.fragment;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import android.app.Fragment;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.LayoutInflater;

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/ChoicesFragment.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/ChoicesFragment.java
@@ -1,7 +1,7 @@
 package com.negusoft.holoaccent.example.fragment;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import android.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/ListFragment.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/ListFragment.java
@@ -1,7 +1,7 @@
 package com.negusoft.holoaccent.example.fragment;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import android.app.Fragment;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
 import android.view.Menu;

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/ProgressFragment.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/ProgressFragment.java
@@ -1,7 +1,7 @@
 package com.negusoft.holoaccent.example.fragment;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import android.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/TextviewFragment.java
+++ b/HoloAccentExample/src/com/negusoft/holoaccent/example/fragment/TextviewFragment.java
@@ -1,7 +1,7 @@
 package com.negusoft.holoaccent.example.fragment;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import android.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;


### PR DESCRIPTION
Created an abstract Activity which handles themeing from XML without
needing to add any methods or fields to the implementation.
Overriding the accent color programmatically requires overriding a
single method in the Activity.

Resulting changes:
- Added AccentActivity
- Added constructor to AccentHelper
- Refactor HoloAccentExample to not rely on android-support-v4 for
  Fragments and FragmentActicity.
- Bumped build tool versions
- Changed support library dependency
